### PR TITLE
Potential fix for code scanning alert no. 22: URL redirection from remote source

### DIFF
--- a/league_manager/views.py
+++ b/league_manager/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
 from django.shortcuts import render, redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.urls import URLPattern, URLResolver
 from django.views import View
 
@@ -19,7 +20,10 @@ class ClearCacheView(View, UserPassesTestMixin):
 
     def get(self, request):
         cache.clear()
-        return redirect(request.META.get('HTTP_REFERER', '/'))
+        referer = request.META.get('HTTP_REFERER', '/')
+        if url_has_allowed_host_and_scheme(referer, allowed_hosts=None):
+            return redirect(referer)
+        return redirect('/')
 
     def test_func(self):
         return self.request.user.is_staff


### PR DESCRIPTION
Potential fix for [https://github.com/dachrisch/league-manager/security/code-scanning/22](https://github.com/dachrisch/league-manager/security/code-scanning/22)

To fix the problem, we need to validate the `HTTP_REFERER` header before using it in the redirect. We can use Django's `url_has_allowed_host_and_scheme` function to ensure that the URL is safe to redirect to. This function checks that the URL is within the allowed hosts and has a valid scheme.

We will modify the `get` method in the `ClearCacheView` class to validate the `HTTP_REFERER` header. If the header is not valid, we will redirect to the home page instead.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
